### PR TITLE
docs: Fix simple typo, executeable -> executable

### DIFF
--- a/src/examples/README.md
+++ b/src/examples/README.md
@@ -196,6 +196,6 @@ Then run command `pack` to pack obfuscated scripts
     cd /path/to/pyarmor
     pyarmor pack -O dist examples/simple/queens.py
 
-Run the final executeable file
+Run the final executable file
 
     dist/queens/queens

--- a/src/user-guide.md
+++ b/src/user-guide.md
@@ -262,7 +262,7 @@ Then run command `pack` to pack obfuscated scripts
 
     pyarmor pack examples/py2exe/hello.py
 
-Run the final executeable file
+Run the final executable file
 
     dist/hello/hello
 
@@ -283,7 +283,7 @@ Then run command `pack` to pack obfuscated scripts
 
      pyarmor pack --type py2exe py2exe/hello.py
 
-Run the final executeable file
+Run the final executable file
 
     cd py2exe/dist
     ./hello


### PR DESCRIPTION
There is a small typo in src/examples/README.md, src/user-guide.md.

Should read `executable` rather than `executeable`.

