### PR TITLE
consuming full number of arguments for error message

### DIFF
--- a/src/helper/repack.py
+++ b/src/helper/repack.py
@@ -298,7 +298,7 @@ def repacker(executable, obfpath, entry=None):
 
 def excepthook(type, exc, traceback):
     if hasattr(exc, 'args'):
-        logging.error(exc.args[0], *exc.args[1:])
+        logging.error(", ".join(['%s'] * len(exc.args)), *exc.args)
     else:
         logging.error('%s', exc)
     sys.exit(1)


### PR DESCRIPTION
An error happened, but the error log output was complaining about not fully consumed message:

> 663 INFO: Repacking EXE "foo_obf"
> --- Logging error ---
> Traceback (most recent call last):
>   File "/usr/lib/python3.8/logging/__init__.py", line 1081, in emit
>     msg = self.format(record)
>   File "/usr/lib/python3.8/logging/__init__.py", line 925, in format
>     return fmt.format(record)
>   File "/usr/lib/python3.8/logging/__init__.py", line 664, in format
>     record.message = record.getMessage()
>   File "/usr/lib/python3.8/logging/__init__.py", line 369, in getMessage
>     msg = msg % self.args
> TypeError: not all arguments converted during string formatting
> Call stack:
>   File "/home/bar/foo/venv/lib/python3.8/site-packages/pyarmor/helper/repack.py", line 301, in excepthook
>     logging.error(exc.args[0], *exc.args[1:])
> Message: 'utf-8'
> Arguments: (b'\x01\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xa5<=\x00\x00\x00\x00\x00\x0b\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00', 24, 25, 'invalid start byte')
> 

This patch is fixing this.