### PR TITLE
Read pyarmor options to end of line

### DIFF
--- a/src/sppmode.py
+++ b/src/sppmode.py
@@ -39,7 +39,7 @@ def _check_inline_option(source):
             break
         i = line.lower().find(marker)
         if i > 0:
-            options.extend(line[i+len(marker)].strip().split(','))
+            options.extend(line[i+len(marker):].strip().split(','))
     return [x.strip() for x in options]
 
 


### PR DESCRIPTION
This is a fix to the parsing code that pulls the options from the inline comment `# pyarmor options: no-spp-mode`

Given the following variables:
```
line = '# pyarmor options: no-spp-mode'
marker = 'pyarmor options:'
i = line.lower().find(marker)
```

The previous code `line[i+len(marker)].strip().split(',')` produces `['']` because it only reads the single character at index `i+len(marker)`.

`line[i+len(marker):]` instead pulls out the substring from the provided index to the end of the string, resulting in options `['no-spp-mode']`. 

