### PR TITLE
Bugfix packing for pyinstaller

### DIFF
--- a/src/packer.py
+++ b/src/packer.py
@@ -437,7 +437,7 @@ def _pyinstaller(src, entry, output, options, xoptions, args):
     logging.info('Save patched .spec file to %s', patched_spec)
 
     logging.info('Run PyInstaller with patched .spec file...')
-    run_command([sys.executable] + packcmd + ['-y', '--clean', patched_spec])
+    run_command([sys.executable] + DEFAULT_PACKER['PyInstaller'][2] + [output] + ['-y', '--clean', patched_spec])
 
     if not args.keep:
         if args.setup is None:


### PR DESCRIPTION
### tl; dr

extra options only for .spec generation
no extra options for pyinstaller itself

##  Problem

In pyinstaller>=5.0 use of params defined in provided .spec file is not possible (I used some options for '...'):

`pyarmor.exe pack --clean --keep -x ' --recursive' -e '...'  --name Name -O dist main.py`
(tb tail)
```pytb
<...>

C:\Users\Administrator\miniconda3\envs\streaming-build\python.exe -m PyInstaller --
distpath dist ... --name Name -y --clean Name-patched.spec


INFO     ==================== Run command ====================
687 INFO: PyInstaller: 5.0.dev0
687 INFO: Python: 3.9.7 (conda)
703 INFO: Platform: Windows-10-10.0.19044-SP0
option(s) not allowed:
  --onedir/--onefile
  --name
  --add-data
  --collect-all
  --additional-hooks-dir
  --debug
  --console/--nowindowed/--windowed/--noconsole
makespec options not valid when a .spec file is given
ERROR    Run command failed
```

Same behaviour on macos machine.