### PR TITLE
Fix nuitka command

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -986,7 +986,7 @@ work. For example, first obfustate the scripts::
 Then translate the obfuscated one as normal python scripts by Nuitka::
 
     cd ./dist
-    python -m nuitka --include-package pytransform foo.py
+    python -m nuitka --include-package=pytransform foo.py
     ./foo.bin
 
 There is one problem is that the imported modules (packages) in the obfuscated


### PR DESCRIPTION
When I tried pyarmor together with nuitka, I noticed that an equal sign is missing.
Here are my specs.

```bash
python -m nuitka --version
0.8
Commercial: None
Python: 3.10.4 (main, Apr  2 2022, 09:04:19) [GCC 11.2.0]
Flavor: Debian Python
OS: Linux
Arch: x86_64
```
