### PR TITLE
docs: Fix a few typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ versions.
 
 It's recommended to read this carefully before upgrading pyarmor.
 
-## [Report issuses](https://github.com/dashingsoft/pyarmor/issues)
+## [Report issues](https://github.com/dashingsoft/pyarmor/issues)
 
 If there is any question, first check these [questions and
 solutions](https://pyarmor.readthedocs.io/en/latest/questions.html), it may help

--- a/docs/platforms.rst
+++ b/docs/platforms.rst
@@ -198,7 +198,7 @@ and run it in the target machine::
 
     python get_platform_name.py
 
-.. note:: New platforms in differnt versions
+.. note:: New platforms in different versions
 
    * v5.9.3: android.armv7
    * v5.9.4: uclibc.armv7

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -11,7 +11,7 @@ Here are some examples:
 * [Check GPU](#example-5-check-gpu)
 
 
-**The sample code is only a guide, it's strongly recommanded to write your
+**The sample code is only a guide, it's strongly recommended to write your
 private code in plugin script**
 
 ##  Example 1: Check All the Mac Address

--- a/src/user-guide.md
+++ b/src/user-guide.md
@@ -605,7 +605,7 @@ optional arguments:
 
 ```
 
-Run benchmark test in current machine. This command used to test the performaces
+Run benchmark test in current machine. This command used to test the performances
 of obfuscated scripts in different obfuscate mode. For examples
 
 
@@ -822,7 +822,7 @@ This command creates an empty project in the specified path - basically a
 configure file .pyarmor_config, a project capsule .pyarmor_capsule.zip, and a
 shell script "pyarmor" will be created (in windows, it called "pyarmor.bat").
 
-Option --type specifies project type: app or package. If it's pakcage type, the
+Option --type specifies project type: app or package. If it's package type, the
 obfuscated scripts will be saved in the sub-directory `package-name` of output
 path. `auto` means project type will be set to package if there is `__init__.py`
 in the project src path, otherwise `app`.
@@ -1059,7 +1059,7 @@ path. This capsule is generated when run command `pyarmor init` to
 create a project. And `license.lic` of PyArmor will be as an input
 file to make this capsule.
 
-When runing command `pyarmor build` or `pyarmor licenses`, it will
+When running command `pyarmor build` or `pyarmor licenses`, it will
 generate a `license.lic` in project output path for obfuscated
 scripts. Here the project capsule `.pyarmor_capsule.zip` will be as
 input file to generate this `license.lic` of Obfuscated Scripts.


### PR DESCRIPTION
There are small typos in:
- README.md
- docs/platforms.rst
- plugins/README.md
- src/user-guide.md

Fixes:
- Should read `running` rather than `runing`.
- Should read `recommended` rather than `recommanded`.
- Should read `performances` rather than `performaces`.
- Should read `package` rather than `pakcage`.
- Should read `different` rather than `differnt`.
- Should read `issues` rather than `issuses`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md