### PR TITLE
Restore setup.py back to configuration that is compatible with pip

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -118,7 +118,7 @@ setup(
 
     entry_points={
         'console_scripts': [
-            'pyarmor=pyarmor',
+            'pyarmor=pyarmor.pyarmor:main_entry',
         ],
     },
 )


### PR DESCRIPTION
See the notes on this issue given here:
https://github.com/dashingsoft/pyarmor/issues/949