### PR TITLE
Fix `reg --buy` KeyError

### DIFF
--- a/src/cli/__main__.py
+++ b/src/cli/__main__.py
@@ -189,7 +189,7 @@ def cmd_cfg(ctx, args):
 def cmd_reg(ctx, args):
     if args.buy:
         from webbrowser import open_new_tab
-        open_new_tab(ctx.cfg['pyarmor', 'buyurl'])
+        open_new_tab(ctx.cfg['pyarmor']['buyurl'])
         return
 
     regfile = args.regfile


### PR DESCRIPTION
Before the fix, executing `pyarmor reg --buy` would throw the following error:
```
  File "{...}/pyarmor/src/cli/__main__.py", line 165, in cmd_reg
    open_new_tab(ctx.cfg['pyarmor', 'buyurl'])
  File "{...}/python3.9/configparser.py", line 963, in __getitem__
    raise KeyError(key)
KeyError: ('pyarmor', 'buyurl')
```