### PR TITLE
Update plugin.py

### DIFF
--- a/src/cli/plugin.py
+++ b/src/cli/plugin.py
@@ -236,10 +236,11 @@ def find_runtime_package(ctx, output):
         return os.path.join(output, rtname)
     if isinstance(prefix, str):
         return os.path.join(output, prefix.replace('.', os.path.sep), rtname)
-    for entry in os.scandir(output):
-        if entry.is_dir():
-            if rtname in os.listdir(entry.path):
-                return os.path.join(entry.path, rtname)
+    with os.scandir(output) as iterator:
+        for entry in iterator:
+            if entry.is_dir():
+                if rtname in os.listdir(entry.path):
+                    return os.path.join(entry.path, rtname)
 
 
 class DarwinUniversalPlugin:


### PR DESCRIPTION
os.scandir allocates resources which are advised to be freed explicitly. pytest also complains about this when running tests which use pyarmor. This pull request changes the usage of os.scandir to how it is documented here: https://docs.python.org/3/library/os.html#os.scandir