### PR TITLE
Introducing Pyarmor Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Please read the [Pyarmor EULA](LICENSE).
 4. **If you still can't find the information you need, see [asking questions on GitHub][asking].**
 5. **[Report bugs][issues] following the issue template.**
 6. **For business and security inquiries, send an email to <pyarmor@163.com>.**
+7. **You can also [Ask Pyarmor Guru][gurubase], it is a Pyarmor-focused AI to answer your questions.**
 
 [faq]: https://pyarmor.readthedocs.io/en/latest/questions.html
 [issues]: https://github.com/dashingsoft/pyarmor/issues
@@ -79,6 +80,7 @@ Please read the [Pyarmor EULA](LICENSE).
 [mastertoc]: https://pyarmor.readthedocs.io/en/stable/index.html#table-of-contents
 [asking]: https://pyarmor.readthedocs.io/en/latest/questions.html#asking-questions-in-github
 [doc]: https://pyarmor.readthedocs.io/
+[gurubase]: https://gurubase.io/g/pyarmor
 
 ## Resources
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Pyarmor Guru](https://gurubase.io/g/pyarmor) to Gurubase. Pyarmor Guru uses the data from this repo and data from the [docs](https://pyarmor.readthedocs.io/en/latest/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Pyarmor Guru", which highlights that Pyarmor now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Pyarmor Guru in Gurubase, just let me know that's totally fine.