### PR TITLE
Fix file encoding detection

### DIFF
--- a/src/cli/resource.py
+++ b/src/cli/resource.py
@@ -124,7 +124,8 @@ class FileResource(Resource):
                     k = n + 1
                     n = line.find(b'\n', k)
                     m = research(r'coding[=:]\s*([-\w.]+)', line[k:n].decode())
-                    return m and m.group(1)
+                    if m:
+                        return m.group(1)
         return encoding
 
     def readlines(self, encoding=None):


### PR DESCRIPTION
如果一个 Python 文件的前两行为以下内容：

```python
# comment 1
# comment 2
```

则`_get_encoding`返回 None，而非传入的`encoding`参数。这会导致部分文件编码检测出现异常。

相关报错：

```plaintext
'gbk' codec can't decode byte 0x89 in position 350: illegal multibyte sequence

## Command Line
C:\Users\a\.venv64\Scripts\pyarmor -d gen -e 3 --pack onefile --enable-jit --enable-themida --assert-call --assert-import --private main.py

## Environments
Python 3.8.20
Pyarmor 9.2.0 (trial), 000000, non-profits
Platform windows.x86_64
Native windows.amd64
Home C:\Users\a\.pyarmor

## Traceback
Traceback (most recent call last):
  File "C:\Users\a\Desktop\package\.venv64\lib\site-packages\pyarmor\cli\__main__.py", line 793, in main
    main_entry(sys.argv[1:])
  File "C:\Users\a\Desktop\package\.venv64\lib\site-packages\pyarmor\cli\__main__.py", line 786, in main_entry
    return args.func(ctx, args)
  File "C:\Users\a\Desktop\package\.venv64\lib\site-packages\pyarmor\cli\__main__.py", line 244, in cmd_gen
    builder.process(options, packer=packer)
  File "C:\Users\a\Desktop\package\.venv64\lib\site-packages\pyarmor\cli\generate.py", line 179, in process
    Pytransform3.pre_build(self.ctx)
  File "C:\Users\a\Desktop\package\.venv64\lib\site-packages\pyarmor\cli\core\__init__.py", line 110, in pre_build
    return m.pre_build(ctx)
  File "<maker>", line 790, in pre_build
  File "<maker>", line 673, in build
  File "<maker>", line 3781, in process
  File "C:\Users\a\Desktop\package\.venv64\lib\site-packages\pyarmor\cli\resource.py", line 145, in reparse
    lines = self.readlines(encoding=encoding)
  File "C:\Users\a\Desktop\package\.venv64\lib\site-packages\pyarmor\cli\resource.py", line 137, in readlines
    lines = f.readlines()
UnicodeDecodeError: 'gbk' codec can't decode byte 0x89 in position 350: illegal multibyte sequence
```